### PR TITLE
ServerSoftware updates

### DIFF
--- a/src/de/cuuky/cfw/version/ServerSoftware.java
+++ b/src/de/cuuky/cfw/version/ServerSoftware.java
@@ -5,27 +5,20 @@ import java.util.function.Supplier;
 
 public enum ServerSoftware {
 
-	// Other
-	UNKNOWN("Unknown", null, null),
-
-	// Base
-	BUKKIT("CraftBukkit", null, "org.bukkit.Bukkit", "CraftBukkit", "Bukkit"),
-	SPIGOT("Spigot", SpigotVersionAdapter::new, "org.spigotmc.SpigotConfig", "Spigot"),
-
-	// Paper
-	PAPER("Paper", SpigotVersionAdapter::new, "co.aikar.timings.Timings", "Paper", "PaperSpigot"),
-	TACO("TacoSpigot", SpigotVersionAdapter::new, "net.techcable.tacospigot.TacoSpigotConfig", "Taco", "TacoSpigot"),
-	NACHO("NachoSpigot", SpigotVersionAdapter::new, "me.elier.nachospigot.config.NachoConfig", "Nacho", "NachoSpigot"),
-	SPORT_PAPER("SportPaper", SpigotVersionAdapter::new, "org.github.paperspigot.SharedConfig", "SportPaper"),
-
-	// Modded
-	@Deprecated // Unused
-	CAULDRON("Cauldron", null, null, "Cauldron"),
-	THERMOS("Thermos", null, "thermos.Thermos", "Thermos"),
+	MAGMA("Magma", versionSupplier -> new MagmaVersionAdapter(), "org.magmafoundation.magma.Magma", "Magma"),
+	CRUCIBLE("Crucible", null, "io.github.crucible.Crucible", "Crucible"),
 	@Deprecated // Unused
 	URANIUM("Uranium", null, null, "Uranium"),
-	CRUCIBLE("Crucible", null, "io.github.crucible.Crucible", "Crucible"),
-	MAGMA("Magma", versionSupplier -> new MagmaVersionAdapter(), "org.magmafoundation.magma.Magma", "Magma");
+	THERMOS("Thermos", null, "thermos.Thermos", "Thermos"),
+	@Deprecated // Unused
+	CAULDRON("Cauldron", null, null, "Cauldron"),
+	SPORT_PAPER("SportPaper", SpigotVersionAdapter::new, "org.github.paperspigot.SharedConfig", "SportPaper"),
+	NACHO("NachoSpigot", SpigotVersionAdapter::new, "me.elier.nachospigot.config.NachoConfig", "Nacho", "NachoSpigot"),
+	TACO("TacoSpigot", SpigotVersionAdapter::new, "net.techcable.tacospigot.TacoSpigotConfig", "Taco", "TacoSpigot"),
+	PAPER("Paper", SpigotVersionAdapter::new, "co.aikar.timings.Timings", "Paper", "PaperSpigot"),
+	SPIGOT("Spigot", SpigotVersionAdapter::new, "org.spigotmc.SpigotConfig", "Spigot"),
+	BUKKIT("CraftBukkit", null, "org.bukkit.Bukkit", "CraftBukkit", "Bukkit"),
+	UNKNOWN("Unknown", null, null);
 
 
 	private static final String FORGE_CLASS = "net.minecraftforge.common.MinecraftForge";
@@ -126,9 +119,12 @@ public enum ServerSoftware {
 		// Don't check every time, it's not going to change
 		if (currentSoftware == null) {
 			// Order is important due to fork chain
-			for (ServerSoftware software : values())
-				if (isClassPresent(software.getIdentifierClass()))
+			for (ServerSoftware software : values()) {
+				if (isClassPresent(software.getIdentifierClass())) {
 					currentSoftware = software;
+					break;
+				}
+			}
 		}
 		return currentSoftware;
 	}

--- a/src/de/cuuky/cfw/version/ServerSoftware.java
+++ b/src/de/cuuky/cfw/version/ServerSoftware.java
@@ -22,7 +22,7 @@ public enum ServerSoftware {
 
 	UNKNOWN("Unknown", null);
 
-	private static final String forgeClass = "net.minecraftforge.common.MinecraftForge";
+	private static final String FORGE_CLASS = "net.minecraftforge.common.MinecraftForge";
 
 	private final String name;
 	private final String[] versionnames;
@@ -41,7 +41,7 @@ public enum ServerSoftware {
 	ServerSoftware(String name, Function<Supplier<VersionAdapter>, VersionAdapter> adapterFunction, String... versionnames) {
 		this.name = name;
 		this.versionnames = versionnames;
-		this.forgeSupport = isClassPresent(forgeClass);
+		this.forgeSupport = isClassPresent(FORGE_CLASS);
 		this.adapterFunction = adapterFunction == null ? Supplier::get : adapterFunction;
 	}
 	/**

--- a/src/de/cuuky/cfw/version/ServerSoftware.java
+++ b/src/de/cuuky/cfw/version/ServerSoftware.java
@@ -102,15 +102,7 @@ public enum ServerSoftware {
 		else
 			return this.adapter;
 	}
-
-	/**
-	 * @return Software the server is running on
-	 * @deprecated use {@link #getServerSoftware()} instead
-	 **/
-	static ServerSoftware getServerSoftware(String version, String name) {
-		return getServerSoftware();
-	}
-
+	
 	/**
 	 * @return Software the server is running on or the next highest one on the fork chain
 	 **/

--- a/src/de/cuuky/cfw/version/VersionUtils.java
+++ b/src/de/cuuky/cfw/version/VersionUtils.java
@@ -42,7 +42,7 @@ public class VersionUtils {
 				nmsClass = base + ".server";
 			}
 			version = BukkitVersion.getVersion(nmsVersion);
-			serverSoftware = ServerSoftware.getServerSoftware(Bukkit.getVersion(), Bukkit.getName());
+			serverSoftware = ServerSoftware.getServerSoftware();
 
 			try {
 				spigot = Bukkit.getServer().getClass().getDeclaredMethod("spigot").invoke(Bukkit.getServer());


### PR DESCRIPTION
- ServerSoftware is now based on Classes instead of Names which prevents issues with renamed forks
- Modsupport isn't hardcoded anymore and will be checked dynamically
- Added SportPaper, NachoSpigot and Crucible
- Deprecated Cauldron and Uranium

- Removed unused arguments in VersionUtils method calls (not needed anymore due to ServerSoftware changes)

~~This should still work without modification to existing plugins since old methods are just deprecated.~~