### PR TITLE
Allow access to underlying YamlConfig

### DIFF
--- a/src/de/cuuky/cfw/configuration/BasicConfigurationHandler.java
+++ b/src/de/cuuky/cfw/configuration/BasicConfigurationHandler.java
@@ -43,4 +43,8 @@ public class BasicConfigurationHandler {
     public int getInt(String name, int defaultValue) {
         return (Integer) getValue(name, defaultValue);
     }
+    
+    public BetterYamlConfiguration getYamlConfig() {
+        return this.configuration;
+    }
 }

--- a/src/de/cuuky/cfw/configuration/BasicConfigurationHandler.java
+++ b/src/de/cuuky/cfw/configuration/BasicConfigurationHandler.java
@@ -1,6 +1,7 @@
 package de.cuuky.cfw.configuration;
 
 import org.bukkit.ChatColor;
+import org.bukkit.configuration.file.YamlConfiguration
 
 public class BasicConfigurationHandler {
 
@@ -44,7 +45,7 @@ public class BasicConfigurationHandler {
         return (Integer) getValue(name, defaultValue);
     }
     
-    public BetterYamlConfiguration getYamlConfig() {
+    public YamlConfiguration getYamlConfig() {
         return this.configuration;
     }
 }


### PR DESCRIPTION
This allows the user to modify the underlying yaml config and for example reload the config without creating a new BasicConfigurationHandler