### PR TITLE
Add nametag entity spawning functionality

### DIFF
--- a/src/main/java/de/varoplugin/cfw/version/OneSevenVersionAdapter.java
+++ b/src/main/java/de/varoplugin/cfw/version/OneSevenVersionAdapter.java
@@ -40,10 +40,12 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Sheep;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.Sign;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.Team;
 
 import com.cryptomorin.xseries.XPotion;
@@ -334,5 +336,23 @@ class OneSevenVersionAdapter implements VersionAdapter {
     @Override
     public void setServerProperty(String key, Object value) {
         this.getServerProperties().setProperty(key, String.valueOf(value));
+    }
+
+    @Override
+    public Entity spawnNametagEntity(Player target, String nametag) {
+        Location location = target.getLocation();
+        World world = target.getWorld();
+
+        // Spawn an invisible baby sheep
+        Sheep sheep = (Sheep) world.spawn(location, Sheep.class);
+        sheep.setBaby();
+        sheep.setInvisible(true);
+        sheep.setCustomName(nametag);
+        sheep.setCustomNameVisible(true);
+
+        // Make the sheep ride the player
+        target.addPassenger(sheep);
+
+        return sheep;
     }
 }

--- a/src/main/java/de/varoplugin/cfw/version/VersionAdapter.java
+++ b/src/main/java/de/varoplugin/cfw/version/VersionAdapter.java
@@ -90,4 +90,6 @@ public interface VersionAdapter {
     Properties getServerProperties();
 
     void setServerProperty(String key, Object value);
+
+    Entity spawnNametagEntity(Player target, String nametag);
 }


### PR DESCRIPTION
This pull request introduces a new feature to the `OneSevenVersionAdapter` class and updates the `VersionAdapter` interface accordingly. The primary change is the addition of a method to spawn a nametag entity, specifically an invisible baby sheep, that rides a player.

### New Feature:

* [`src/main/java/de/varoplugin/cfw/version/OneSevenVersionAdapter.java`](diffhunk://#diff-a868901630d538899398b8b814e463bbeeef96eca7265ca6e94a0132d0dd2a6bR340-R357): Added the `spawnNametagEntity` method to spawn an invisible baby sheep with a custom name that rides a player.

### Interface Update:

* [`src/main/java/de/varoplugin/cfw/version/VersionAdapter.java`](diffhunk://#diff-87ed14c37774100f687bb701e6147889f56bb5a7e7f4c8824d81491b8a0fb3d6R93-R94): Updated the `VersionAdapter` interface to include the `spawnNametagEntity` method.

### Import Statements:

* [`src/main/java/de/varoplugin/cfw/version/OneSevenVersionAdapter.java`](diffhunk://#diff-a868901630d538899398b8b814e463bbeeef96eca7265ca6e94a0132d0dd2a6bR43-R48): Added import statements for `Sheep` and `PotionEffectType` to support the new feature.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CuukyOfficial/CFW/pull/35?shareId=34d1aeda-09a6-4218-9a42-5b56c4d82c73).